### PR TITLE
Github Action script added for building Docker image and pushing it Dockerhub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,16 @@
+name: Create Docker image and push to Dockerhub
+on:
+  push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and publish on Dockerhub
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: matmu/fq
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASS }}
+        dockerfile: Dockerfile
+        tags: "v0.9.1"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Create Docker image and push to Dockerhub
 on:
-  push
+  push:
+    tags:        
+      - '*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,4 +15,4 @@ jobs:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASS }}
         dockerfile: Dockerfile
-        tags: "v0.9.1"
+        tags: ${{ github.ref_name }}


### PR DESCRIPTION
I have added a Github Action script that builds the Docker image and pushes it to Dockerhub when a new tag is created. 

To make it work, you just need to set secrets `DOCKER_USER` and `DOCKER_PASS` (username and access token from Dockerhub) in your Github repo and adapt the Dockerhub repo name in `.github/workflows/docker.yml` accordingly (currently matmu/fq). 
I can also give you my credentials if you like.

Great tool!