### PR TITLE
commands/filter: Add filter by sequence pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+  * commands/filter: Add filter by sequence pattern ([#27]).
+
+    Records can be filtered by their sequence using a regular expression: `fq
+    filter --sequence-pattern <regex> <src>`. It cannot be combined with name
+    filtering.
+
+[#27]: https://github.com/stjude-rust-labs/fq/issues/27
+
 ### Changed
 
   * commands/subsample: Disallow 0% and 100% as probabilities.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +170,7 @@ dependencies = [
  "git-testament",
  "rand",
  "rand_distr",
+ "regex",
  "tracing",
  "tracing-subscriber",
 ]
@@ -280,6 +290,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniz_oxide"
@@ -433,6 +449,23 @@ dependencies = [
  "num-traits",
  "rand",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ flate2 = "1.0.14"
 git-testament = "0.2.0"
 rand = { version = "0.8.1", features = ["small_rng"] }
 rand_distr = { version = "0.4.0" }
+regex = "1.7.1"
 tracing = "0.1.25"
 tracing-subscriber = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -71,23 +71,28 @@ validating FASTQ files.
 
 ### filter
 
-**fq filter** takes an allowlist of record names and filters a given FASTQ
-file. The result includes only the records in the allowlist.
+**fq filter** filters a given FASTQ file by a set of names or a sequence
+pattern. The result includes only the records that match the given options.
 
 #### Usage
 
 ```
 Filters a FASTQ from an allowlist of names
 
-Usage: fq filter --names <NAMES> <SRC>
+Usage: fq filter [OPTIONS] <SRC>
 
 Arguments:
   <SRC>  Source FASTQ
 
 Options:
-      --names <NAMES>  Allowlist of record names
-  -h, --help           Print help
-  -V, --version        Print version
+      --names <NAMES>
+          Allowlist of record names
+      --sequence-pattern <SEQUENCE_PATTERN>
+          Keep records that have sequences that match the given regular expression
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 #### Examples

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use clap::{ArgGroup, Parser, Subcommand};
 use git_testament::{git_testament, render_testament};
+use regex::bytes::Regex;
 
 use crate::{validators::LintMode, ValidationLevel};
 
@@ -19,7 +20,7 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Command {
-    /// Filters a FASTQ from an allowlist of names.
+    /// Filters a FASTQ file.
     Filter(FilterArgs),
     /// Generates a random FASTQ file pair.
     Generate(GenerateArgs),
@@ -30,10 +31,15 @@ pub enum Command {
 }
 
 #[derive(Parser)]
+#[command(group(ArgGroup::new("filter").args(["names", "sequence_pattern"])))]
 pub struct FilterArgs {
     /// Allowlist of record names.
     #[arg(long)]
     pub names: Option<PathBuf>,
+
+    /// Keep records that have sequences that match the given regular expression.
+    #[arg(long)]
+    pub sequence_pattern: Option<Regex>,
 
     /// Source FASTQ.
     pub src: PathBuf,


### PR DESCRIPTION
Records can be filtered by their sequence using a regular expression: `fq filter --sequence-pattern <regex> <src>`. It cannot be combined with name filtering.

Closes #27.