### PR TITLE
commands/filter: Support multiple segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,25 @@
   * commands/filter: Add filter by sequence pattern ([#27]).
 
     Records can be filtered by their sequence using a regular expression: `fq
-    filter --sequence-pattern <regex> <src>`. It cannot be combined with name
-    filtering.
+    filter --sequence-pattern <regex> --dsts <dst> <src>`. It cannot be
+    combined with name filtering.
 
 [#27]: https://github.com/stjude-rust-labs/fq/issues/27
 
 ### Changed
 
+  * commands/filter: Support multiple segments ([#30]).
+
+    The `filter` command now supports multiple segments. Each source is paired
+    with a destination (i.e., the output is no longer written to stdout by
+    default), which is filtered by whether the record in the first segment is
+    matched.
+
   * commands/subsample: Disallow 0% and 100% as probabilities.
 
     At these extremes, use `touch` and `cp`, respectively, instead.
+
+[#30]: https://github.com/stjude-rust-labs/fq/issues/30
 
 ## 0.9.1 - 2022-02-15
 

--- a/README.md
+++ b/README.md
@@ -77,18 +77,20 @@ pattern. The result includes only the records that match the given options.
 #### Usage
 
 ```
-Filters a FASTQ from an allowlist of names
+Filters a FASTQ file
 
-Usage: fq filter [OPTIONS] <SRC>
+Usage: fq filter [OPTIONS] --dsts <DSTS> [SRCS]...
 
 Arguments:
-  <SRC>  Source FASTQ
+  [SRCS]...  FASTQ sources
 
 Options:
       --names <NAMES>
           Allowlist of record names
       --sequence-pattern <SEQUENCE_PATTERN>
           Keep records that have sequences that match the given regular expression
+      --dsts <DSTS>
+          Filtered FASTQ destinations
   -h, --help
           Print help
   -V, --version

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,8 +41,12 @@ pub struct FilterArgs {
     #[arg(long)]
     pub sequence_pattern: Option<Regex>,
 
-    /// Source FASTQ.
-    pub src: PathBuf,
+    /// Filtered FASTQ destinations.
+    #[arg(long, required = true)]
+    pub dsts: Vec<PathBuf>,
+
+    /// FASTQ sources.
+    pub srcs: Vec<PathBuf>,
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
The `filter` command now supports multiple segments. Each source is paired with a destination (i.e., the output is no longer written to stdout by default), which is filtered by whether the record in the first segment is matched.

Closes https://github.com/stjude-rust-labs/fq/issues/30.